### PR TITLE
Bug fix for conflict of ajax and submit closes #107

### DIFF
--- a/wiggum_app/templates/index.html
+++ b/wiggum_app/templates/index.html
@@ -183,6 +183,7 @@
                     type: 'POST',
                     url: '/',
                     data: form_data,
+                    async: false,
                     contentType: false,
                     cache: false,
                     processData: false,


### PR DESCRIPTION
When click visualize button for COMPAS dataset, app can not reach action == 'visualize' in controller.py.