### PR TITLE
add counts to trend_precompute

### DIFF
--- a/tests/test_01_basic_demo.py
+++ b/tests/test_01_basic_demo.py
@@ -93,6 +93,12 @@ def test_basic_load_df():
     labeled_df.get_subgroup_trends_1lev([rankobj,linreg_obj])
     labeled_df.get_pairwise_trends_1lev([rankobj,linreg_obj])
 
+    # confirm that rankobj trends trend_precompute has the right columns
+    sel_trend = '_'.join([rankobj.name,'agg_trend','search_conducted_rate',
+                        'driver_gender'])
+
+    for reqcol in ['stat','max','min','count']:
+        assert reqcol in labeled_df.trend_list[1].trend_precompute[sel_trend].columns
     # These  two methods give the same, the string based version allows for simple access to default setting but passing a trend object would allow for overriding defaults and creating more custom subests of trends.
 
     labeled_df.add_distance(row_wise = True)

--- a/wiggum/trend_components/categorical.py
+++ b/wiggum/trend_components/categorical.py
@@ -68,7 +68,7 @@ class StatBinRankTrend():
             statistic to compute, must be compatible with DataFrame.apply,
             have the interface (self,df,statfeat,weightfeat) and return a Series
             with 'stat', 'max', 'min' values defining the statistic and a
-            confidence interval
+            confidence interval and 'count' defining the power of the computation
         trendgroup : list of strings
             list of variable names to be ranked (and used for grouping in this
             method)


### PR DESCRIPTION
add count column to stat tables for ranking and add a test to verify that the columns as needed exist, confirming this add occurs. 

updates to documentation in api where the stat functions are called to note the requirements for user-specified functions

